### PR TITLE
Add a warning about including remote image (because of issue with PDF document generation)

### DIFF
--- a/template-computo-python.qmd
+++ b/template-computo-python.qmd
@@ -192,6 +192,7 @@ It is also possible to create figures from static images:
 Computo logo (label)
 :::
 
+**Note:** _Until Quarto version 1.3+ is released, including a remote image (from a web URL) in a document (like the image above) will work in the rendered HTML document but will generate an error when building the PDF document (c.f. [related bug report](https://github.com/quarto-dev/quarto-cli/issues/4443))._
 
 ## Tables
 


### PR DESCRIPTION
Temporary warning for #2 because of https://github.com/quarto-dev/quarto-cli/issues/4443 (will be fixed with quarto 1.3+ release).

> **Note:** _Until Quarto version 1.3+ is released, including a remote image (from a web URL) in a document (like the image above) will work in the rendered HTML document but will generate an error when building the PDF document (c.f. [related bug report](https://github.com/quarto-dev/quarto-cli/issues/4443))._